### PR TITLE
Parse the hangout link from the event.

### DIFF
--- a/package/contents/ui/calendars/GoogleCalendarManager.qml
+++ b/package/contents/ui/calendars/GoogleCalendarManager.qml
@@ -200,6 +200,7 @@ CalendarManager {
 
 	function parseEvent(calendar, event) {
 		event.description = event.description || ""
+		event.hangoutLink = event.hangoutLink || "";
 		event.backgroundColor = parseColor(calendar, event)
 		event.canEdit = (calendar.accessRole == 'writer' || calendar.accessRole == 'owner') && !event.recurringEventId // We cannot currently edit repeating events.
 		if (true && event.htmlLink) {


### PR DESCRIPTION
I was testing this plasmoid building it directly and it missed the hangoutLink parsing. The DebugFixtures had the info but no real parsing was being made when downloading the events. Since I use daily, this is of great use for me and I suppose it just enables a feature you already developed :)