### PR TITLE
Allow double click to do nothing

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -120,6 +120,9 @@
 		<entry name="month_show_weeknumbers" type="bool">
 			<default>false</default>
 		</entry>
+		<entry name="double_click_option" type="string">
+			<default>googleCalWeb</default>
+		</entry>
 		<entry name="month_eventbadge_type" type="string">
 			<default>theme</default>
 		</entry>

--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -120,8 +120,8 @@
 		<entry name="month_show_weeknumbers" type="bool">
 			<default>false</default>
 		</entry>
-		<entry name="double_click_option" type="string">
-			<default>googleCalWeb</default>
+		<entry name="monthDayDoubleClick" type="string">
+			<default>GoogleCalWeb</default>
 		</entry>
 		<entry name="month_eventbadge_type" type="string">
 			<default>theme</default>

--- a/package/contents/ui/PopupView.qml
+++ b/package/contents/ui/PopupView.qml
@@ -350,15 +350,15 @@ MouseArea {
 			onDayDoubleClicked: {
 				var date = new Date(dayData.yearNumber, dayData.monthNumber-1, dayData.dayNumber)
 				// logger.debug('Popup.monthView.onDoubleClicked', date)
-                var doubleClickOption = plasmoid.configuration.double_click_option
+				var doubleClickOption = plasmoid.configuration.monthDayDoubleClick
 
-                switch (doubleClickOption) {
-                    case 'googleCalWeb':
-                        Shared.openGoogleCalendarNewEventUrl(date)
-                        return
-                    default:
-                        return
-                }
+				switch (doubleClickOption) {
+					case 'GoogleCalWeb':
+						Shared.openGoogleCalendarNewEventUrl(date)
+						return
+					default:
+						return
+				}
 			}
 		} // MonthView
 

--- a/package/contents/ui/PopupView.qml
+++ b/package/contents/ui/PopupView.qml
@@ -350,10 +350,15 @@ MouseArea {
 			onDayDoubleClicked: {
 				var date = new Date(dayData.yearNumber, dayData.monthNumber-1, dayData.dayNumber)
 				// logger.debug('Popup.monthView.onDoubleClicked', date)
-				if (true) {
-					// month_day_doubleclick == "browser_newevent"
-					Shared.openGoogleCalendarNewEventUrl(date)
-				}
+                var doubleClickOption = plasmoid.configuration.double_click_option
+
+                switch (doubleClickOption) {
+                    case 'googleCalWeb':
+                        Shared.openGoogleCalendarNewEventUrl(date)
+                        return
+                    default:
+                        return
+                }
 			}
 		} // MonthView
 

--- a/package/contents/ui/config/ConfigCalendar.qml
+++ b/package/contents/ui/config/ConfigCalendar.qml
@@ -25,15 +25,15 @@ ConfigPage {
 	}
 
 	ConfigSection {
-        ConfigRadioButtonGroup {
-            id: doubleClickDateGroup
-            label: i18n("Double-click on Date:")
-            configKey: 'double_click_option'
-            model: [
-                { value: 'googleCalWeb', text: i18n("Google Calender (Open Web)")  },
-                { value: 'doNothing', text: i18n("Do Nothing") },
-            ]
-        }
+		ConfigRadioButtonGroup {
+			id: doubleClickDateGroup
+			label: i18n("Double-click on Date:")
+			configKey: 'monthDayDoubleClick'
+			model: [
+				{ value: 'GoogleCalWeb', text: i18n("New Google Calendar Event (Web Browser)")  },
+				{ value: 'DoNothing', text: i18n("Do Nothing") },
+			]
+		}
 	}
 
 	HeaderText {

--- a/package/contents/ui/config/ConfigCalendar.qml
+++ b/package/contents/ui/config/ConfigCalendar.qml
@@ -25,15 +25,15 @@ ConfigPage {
 	}
 
 	ConfigSection {
-		ConfigRadioButtonGroup {
-			id: doubleClickDateGroup
-			label: i18n("DoubleClick Date:")
-			RadioButton {
-				text: i18n("Open New Event In Browser")
-				exclusiveGroup: doubleClickDateGroup.exclusiveGroup
-				checked: true
-			}
-		}
+        ConfigRadioButtonGroup {
+            id: doubleClickDateGroup
+            label: i18n("Double-click on Date:")
+            configKey: 'double_click_option'
+            model: [
+                { value: 'googleCalWeb', text: i18n("Google Calender (Open Web)")  },
+                { value: 'doNothing', text: i18n("Do Nothing") },
+            ]
+        }
 	}
 
 	HeaderText {


### PR DESCRIPTION
As per: disable double click #116 . This also sets it up to allow other double click options - I will also pursuit allowing double click to launch korganizer.