### PR TITLE
Remove "This event was added from Goals..." from event description

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -382,6 +382,10 @@
 		<entry name="tasklistIdList" type="string">
 			<default></default>
 		</entry>
+		<entry name="gcalHideGoalsDesc" type="bool">
+			<label>Remove "This event was added from Goals in Google Calendar" from description</label>
+			<default>false</default>
+		</entry>
 
 		<!-- Deprecated in: v71 -->
 		<entry name="access_token" type="string">

--- a/package/contents/ui/calendars/GoogleCalendarManager.qml
+++ b/package/contents/ui/calendars/GoogleCalendarManager.qml
@@ -260,6 +260,10 @@ CalendarManager {
 
 	function parseEvent(calendar, event) {
 		event.description = event.description || ""
+		if (plasmoid.configuration.gcalHideGoalsDesc && 
+			event.description.includes("This event was added from Goals in Google Calendar")) {
+			event.description = ""
+		}
 		event.backgroundColor = parseColor(calendar, event)
 		event.canEdit = (calendar.accessRole == 'writer' || calendar.accessRole == 'owner') && !event.recurringEventId // We cannot currently edit repeating events.
 		if (true && event.htmlLink) {

--- a/package/contents/ui/calendars/GoogleCalendarManager.qml
+++ b/package/contents/ui/calendars/GoogleCalendarManager.qml
@@ -261,7 +261,8 @@ CalendarManager {
 	function parseEvent(calendar, event) {
 		event.description = event.description || ""
 		if (plasmoid.configuration.gcalHideGoalsDesc && 
-			event.description.includes("This event was added from Goals in Google Calendar")) {
+			event.organizer.email == "unknownorganizer@calendar.google.com" &&
+			event.organizer.displayName == "Google Calendar") {
 			event.description = ""
 		}
 		event.backgroundColor = parseColor(calendar, event)

--- a/package/contents/ui/config/ConfigGoogleCalendar.qml
+++ b/package/contents/ui/config/ConfigGoogleCalendar.qml
@@ -338,6 +338,11 @@ ConfigPage {
 		}
 	}
 
+	ConfigCheckBox {
+		configKey: 'gcalHideGoalsDesc'
+		text: i18n("Remove \"This event was added from Goals in Google Calendar\" from description")
+	}
+
 	Component.onCompleted: {
 		if (googleLoginManager.isLoggedIn) {
 			googleLoginManager.calendarListChanged()


### PR DESCRIPTION
Google has recently introduced Goals, which are different from Tasks. They are part of the default Events calendar, and automatically change their scheduled times.

The issue is the API automatically populates their description field with `This event was added from Goals in Google Calendar. Changes made to it here may not save. Use the Google Calendar app to edit and view Goal details.` for every such event (not visible in the official clients) and unnecessarily pollutes the agenda view.

This PR adds a simple check which clears the description field if this message is present. I've also added a config option to toggle this check, but couldn't figure out how to auto-refresh the events when toggled. For now, after modifying the checkbox, the user has to manually refresh the calendar to see the update. Would appreciate your help in fixing this.