### PR TITLE
Show Zoom link

### DIFF
--- a/package/contents/ui/AgendaEventItem.qml
+++ b/package/contents/ui/AgendaEventItem.qml
@@ -204,7 +204,8 @@ LinkRect {
 
 			Loader {
 				id: eventHangoutLinkLoader
-				readonly property bool showProperty: plasmoid.configuration.agendaShowEventHangoutLink && !!model.hangoutLink
+				readonly property bool showProperty: plasmoid.configuration.agendaShowEventHangoutLink && !!externalLink
+				readonly property string externalLink: model.hangoutLink || model.conferenceData && model.conferenceData.entryPoints && model.conferenceData.entryPoints[0].uri || ''
 				visible: showProperty && !editEventForm.visible
 				active: visible
 
@@ -221,7 +222,7 @@ LinkRect {
 						}
 					}
 					icon.source: plasmoid.file("", "icons/hangouts.svg")
-					onClicked: Qt.openUrlExternally(model.hangoutLink)
+					onClicked: Qt.openUrlExternally(externalLink)
 				}
 			}
 


### PR DESCRIPTION
Hi, I came across #63 and I was able to get Zoom links to show up in the agenda. This is how it looks like for me:

![Screenshot_20210504_122046](https://user-images.githubusercontent.com/815873/118667802-997de500-b7f4-11eb-9d3e-83416ba2ea69.png)

Clicking on the button opens the Zoom conference URL in the browser and I've been using this for a couple of weeks with no issues.