### PR TITLE
Fix broken datetime format in ja.po

### DIFF
--- a/package/translate/ja.po
+++ b/package/translate/ja.po
@@ -764,22 +764,22 @@ msgstr "全てのファイル (%1)"
 #: ../contents/ui/LocaleFuncs.js
 msgctxt "event time on the hour (24 hour clock)"
 msgid "h"
-msgstr "1時間のイベント (24h)"
+msgstr ""
 
 #: ../contents/ui/LocaleFuncs.js
 msgctxt "event time (24 hour clock)"
 msgid "h:mm"
-msgstr "イベントタイム (24h)"
+msgstr ""
 
 #: ../contents/ui/LocaleFuncs.js
 msgctxt "event time on the hour (12 hour clock)"
 msgid "h AP"
-msgstr "1時間のイベント(12h)"
+msgstr ""
 
 #: ../contents/ui/LocaleFuncs.js
 msgctxt "event time (12 hour clock)"
 msgid "h:mm AP"
-msgstr "イベントタイム (12h)"
+msgstr ""
 
 #: ../contents/ui/LocaleFuncs.js
 msgctxt "date (%1) with time (%2)"


### PR DESCRIPTION
Present situation
---------------------

When the language is Japanese, event time is not properly shown.

Expected:
Show event time e.g. "10:30"

Actual:
Show strings e.g. "イベントタイム(2410)"

What I fixed
---------------

Change msgstr in `ja.po`.