### PR TITLE
[Google] Open events in view mode instead of edit

### DIFF
--- a/package/contents/ui/calendars/GoogleCalendarManager.qml
+++ b/package/contents/ui/calendars/GoogleCalendarManager.qml
@@ -271,7 +271,7 @@ CalendarManager {
 			if (eidMatch) {
 				var eid = eidMatch[1]
 				if (eid) {
-					event.htmlLink = 'https://calendar.google.com/calendar/r/eventedit/' + eid
+					event.htmlLink = 'https://calendar.google.com/calendar/event?action=VIEW&eid=' + eid
 				}
 			}
 		}


### PR DESCRIPTION
This PR updates the Google Calendar event url to open it in view mode (a modal with event's details) instead of edit mode.
This prevents unwanted modifications, especially in workspace environment as we deal with mostly RSVP events from colleagues:
- Sometimes we just want to reply yes or no
- Or to only display the event in a bigger calendar (in order to have a context)
- Or to only show participants

If you want to keep a shortcut to edit the event, I suggest to add a pencil button for this purpose (not in this PR, I don't know how to do it).