### PR TITLE
Hide network error following an `allDataFetched` event

### DIFF
--- a/package/contents/ui/Logic.qml
+++ b/package/contents/ui/Logic.qml
@@ -223,6 +223,7 @@ Item {
 		}
 		onAllDataFetched: {
 			logger.debug('onAllDataFetched')
+			if (logic.currentErrorType == ErrorType.NetworkError) logic.clearError()
 			if (popup) popup.deferredUpdateUI()
 		}
 		onEventCreated: {


### PR DESCRIPTION
See #292.

Fixes Zren/plasma-applet-eventcalendar#292
Fixes Zren/plasma-applet-eventcalendar#273