### PR TITLE
Add an option to expand the widget in Desktop view and Panels

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -72,6 +72,9 @@
 		<entry name="showBackground" type="bool">
 			<default>true</default>
 		</entry>
+		<entry name="forceExpanded" type="bool">
+			<default>false</default>
+		</entry>
 		<entry name="topRowHeight" type="uint">
 			<default>100</default>
 		</entry>

--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -247,6 +247,9 @@
 		<entry name="agendaBreakupMultiDayEvents" type="bool">
 			<default>false</default>
 		</entry>
+		<entry name="agendaBreakupReccurentEvents" type="bool">
+			<default>true</default>
+		</entry>
 		<entry name="agendaNewEventRememberCalendar" type="bool">
 			<default>true</default>
 		</entry>

--- a/package/contents/ui/AgendaModel.qml
+++ b/package/contents/ui/AgendaModel.qml
@@ -249,6 +249,24 @@ ListModel {
 
 		var agendaItemList = []
 
+		/* Filter out reccurent events to show only the closest one */
+		if (!plasmoid.configuration.agendaBreakupReccurentEvents) {
+		const sortedEventsByReccurence = data.items.reduce((reccurentEvents,event) => {
+			if (reccurentEvents[event.summary] && reccurentEvents[event.summary].find(e => e.id !== event.id && e.summary === event.summary)) {
+				reccurentEvents[event.summary].push(event)
+			}
+			else { 
+				reccurentEvents[event.summary] = [];
+				reccurentEvents[event.summary].push(event); }
+			return reccurentEvents;
+		},{})
+
+		data.items = Object.values(sortedEventsByReccurence).map(events => events.filter(event => {
+			const today = new Date(new Date().setHours(0,0,0,0));
+			return event.startDateTime <= today;
+		} )[0] || events[0])
+		}
+
 		for (var i = 0; i < data.items.length; i++) {
 			var eventItem = data.items[i]
 			if (plasmoid.configuration.agendaBreakupMultiDayEvents) {

--- a/package/contents/ui/config/ConfigAgenda.qml
+++ b/package/contents/ui/config/ConfigAgenda.qml
@@ -135,6 +135,17 @@ ConfigPage {
 	}
 
 	ConfigSection {
+		ConfigRadioButtonGroup {
+			configKey: 'agendaBreakupReccurentEvents'
+			label: i18n("Show reccurent events:")
+			model: [
+				{ value: true, text: i18n("On all days") },
+				{ value: false, text: i18n("Only on the first and current day") },
+			]
+		}
+	}
+
+	ConfigSection {
 		ConfigCheckBox {
 			configKey: 'agendaNewEventRememberCalendar'
 			text: i18n("Remember selected calendar in New Event Form")

--- a/package/contents/ui/config/ConfigGeneral.qml
+++ b/package/contents/ui/config/ConfigGeneral.qml
@@ -337,6 +337,11 @@ ConfigPage {
 			Layout.fillWidth: true
 			text: i18n("Desktop Widget: Show background")
 		}
+		ConfigCheckBox {
+			configKey: 'fillPanel'
+			Layout.fillWidth: true
+			text: i18n("Fill the widget in the panel")
+		}
 	}
 
 	HeaderText {

--- a/package/contents/ui/config/ConfigGeneral.qml
+++ b/package/contents/ui/config/ConfigGeneral.qml
@@ -338,9 +338,9 @@ ConfigPage {
 			text: i18n("Desktop Widget: Show background")
 		}
 		ConfigCheckBox {
-			configKey: 'fillPanel'
+			configKey: 'forceExpanded'
 			Layout.fillWidth: true
-			text: i18n("Fill the widget in the panel")
+			text: i18n("Always keep expanded (Experimental)")
 		}
 	}
 

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -129,7 +129,7 @@ Item {
 		// * the timer widget is enabled since there's room in the top right
 		property bool isPinVisible: {
 			// plasmoid.location == PlasmaCore.Types.Floating when using plasmawindowed and when used as a desktop widget.
-			return plasmoid.location != PlasmaCore.Types.Floating && !plasmoid.configuration.fillPanel // && plasmoid.configuration.widget_show_pin
+			return plasmoid.location != PlasmaCore.Types.Floating && !plasmoid.configuration.forceExpanded // && plasmoid.configuration.widget_show_pin
 		}
 		padding: {
 			if (isPinVisible && !(plasmoid.configuration.widgetShowTimer || plasmoid.configuration.widgetShowMeteogram)) {
@@ -194,7 +194,7 @@ Item {
 	Plasmoid.backgroundHints: plasmoid.configuration.showBackground ? PlasmaCore.Types.DefaultBackground : PlasmaCore.Types.NoBackground
 
 	property bool isDesktopContainment: plasmoid.location == PlasmaCore.Types.Floating
-	Plasmoid.preferredRepresentation: plasmoid.configuration.fillPanel ? Plasmoid.fullRepresentation : Plasmoid.compactRepresentation
+	Plasmoid.preferredRepresentation: plasmoid.configuration.forceExpanded ? Plasmoid.fullRepresentation : Plasmoid.compactRepresentation
 	Plasmoid.compactRepresentation: clockComponent
 	Plasmoid.fullRepresentation: popupComponent
 

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -194,7 +194,7 @@ Item {
 	Plasmoid.backgroundHints: plasmoid.configuration.showBackground ? PlasmaCore.Types.DefaultBackground : PlasmaCore.Types.NoBackground
 
 	property bool isDesktopContainment: plasmoid.location == PlasmaCore.Types.Floating
-	Plasmoid.preferredRepresentation: isDesktopContainment ? Plasmoid.fullRepresentation : Plasmoid.compactRepresentation
+	Plasmoid.preferredRepresentation: plasmoid.configuration.fillPanel ? Plasmoid.fullRepresentation : Plasmoid.compactRepresentation
 	Plasmoid.compactRepresentation: clockComponent
 	Plasmoid.fullRepresentation: popupComponent
 

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -129,7 +129,7 @@ Item {
 		// * the timer widget is enabled since there's room in the top right
 		property bool isPinVisible: {
 			// plasmoid.location == PlasmaCore.Types.Floating when using plasmawindowed and when used as a desktop widget.
-			return plasmoid.location != PlasmaCore.Types.Floating // && plasmoid.configuration.widget_show_pin
+			return plasmoid.location != PlasmaCore.Types.Floating && !plasmoid.configuration.fillPanel // && plasmoid.configuration.widget_show_pin
 		}
 		padding: {
 			if (isPinVisible && !(plasmoid.configuration.widgetShowTimer || plasmoid.configuration.widgetShowMeteogram)) {

--- a/package/translate/fr.po
+++ b/package/translate/fr.po
@@ -529,6 +529,10 @@ msgid "Desktop Widget: Show background"
 msgstr "Widget de bureau: Afficher le fond d'écran"
 
 #: ../contents/ui/config/ConfigGeneral.qml
+msgid "Always keep expanded (Experimental)"
+msgstr "Toujours garder l'affichage étendu (Experimental)"
+
+#: ../contents/ui/config/ConfigGeneral.qml
 msgid "Debugging"
 msgstr "Débogage"
 


### PR DESCRIPTION
Note for Latte-dock users: The concerned panel must be set to normal window (sys settings) to allow accepting the focus/input