### PR TITLE
Add an option to display reccurent events once

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -244,6 +244,9 @@
 		<entry name="agendaBreakupMultiDayEvents" type="bool">
 			<default>false</default>
 		</entry>
+		<entry name="agendaBreakupReccurentEvents" type="bool">
+			<default>true</default>
+		</entry>
 		<entry name="agendaNewEventRememberCalendar" type="bool">
 			<default>true</default>
 		</entry>

--- a/package/contents/ui/AgendaModel.qml
+++ b/package/contents/ui/AgendaModel.qml
@@ -249,6 +249,24 @@ ListModel {
 
 		var agendaItemList = []
 
+		/* Filter out reccurent events to show only the closest one */
+		if (!plasmoid.configuration.agendaBreakupReccurentEvents) {
+		const sortedEventsByReccurence = data.items.reduce((reccurentEvents,event) => {
+			if (reccurentEvents[event.summary] && reccurentEvents[event.summary].find(e => e.id !== event.id && e.summary === event.summary)) {
+				reccurentEvents[event.summary].push(event)
+			}
+			else { 
+				reccurentEvents[event.summary] = [];
+				reccurentEvents[event.summary].push(event); }
+			return reccurentEvents;
+		},{})
+
+		data.items = Object.values(sortedEventsByReccurence).map(events => events.filter(event => {
+			const today = new Date(new Date().setHours(0,0,0,0));
+			return event.startDateTime >= today;
+		} )[0] || events[0])
+		}
+
 		for (var i = 0; i < data.items.length; i++) {
 			var eventItem = data.items[i]
 			if (plasmoid.configuration.agendaBreakupMultiDayEvents) {

--- a/package/contents/ui/config/ConfigAgenda.qml
+++ b/package/contents/ui/config/ConfigAgenda.qml
@@ -135,6 +135,17 @@ ConfigPage {
 	}
 
 	ConfigSection {
+		ConfigRadioButtonGroup {
+			configKey: 'agendaBreakupReccurentEvents'
+			label: i18n("Show reccurent events:")
+			model: [
+				{ value: true, text: i18n("On all days") },
+				{ value: false, text: i18n("Only on the first and current day") },
+			]
+		}
+	}
+
+	ConfigSection {
 		ConfigCheckBox {
 			configKey: 'agendaNewEventRememberCalendar'
 			text: i18n("Remember selected calendar in New Event Form")


### PR DESCRIPTION
I find reccurent events to be very verbose and they take up a lot of space. So I added an option to only show them on the current/closest day.
I show them when `eventItem.startDateTime >= today` but logic might change in the future