### PR TITLE
add quick tweaks to identify past events

### DIFF
--- a/package/contents/ui/AgendaEventItem.qml
+++ b/package/contents/ui/AgendaEventItem.qml
@@ -15,6 +15,8 @@ LinkRect {
 	implicitHeight: contents.implicitHeight
 
 	property bool eventItemInProgress: false
+	property bool eventItemInPast: false
+
 	function checkIfInProgress() {
 		if (model.startDateTime && timeModel.currentTime && model.endDateTime) {
 			eventItemInProgress = model.startDateTime <= timeModel.currentTime && timeModel.currentTime <= model.endDateTime
@@ -22,6 +24,11 @@ LinkRect {
 			eventItemInProgress = false
 		}
 		// console.log('checkIfInProgress()', model.start, timeModel.currentTime, model.end)
+		if (model.startDateTime && timeModel.currentTime && model.endDateTime) {
+			eventItemInPast = model.endDateTime < timeModel.currentTime
+		} else {
+			eventItemInPast = false
+		}
 	}
 	Connections {
 		target: timeModel
@@ -118,13 +125,16 @@ LinkRect {
 			PlasmaComponents3.Label {
 				id: eventSummary
 				text: {
+					var eventBullet = eventItemInPast ? '✓ ' : ' '
 					if (isCondensed && model.location) {
-						return model.summary + " | " + model.location
+						return eventBullet + model.summary + " | " + model.location
 					} else {
-						return model.summary
+						return eventBullet + model.summary
 					}
 				}
-				color: eventItemInProgress ? inProgressColor : PlasmaCore.ColorScope.textColor
+				color: {
+					eventItemInPast ? PlasmaCore.ColorScope.disabledTextColor : (eventItemInProgress ? inProgressColor : PlasmaCore.ColorScope.textColor)
+				}
 				font.pointSize: -1
 				font.pixelSize: appletConfig.agendaFontSize
 				font.weight: eventItemInProgress ? inProgressFontWeight : Font.Normal
@@ -146,8 +156,8 @@ LinkRect {
 						return eventTimestamp
 					}
 				}
-				color: eventItemInProgress ? inProgressColor : PlasmaCore.ColorScope.textColor
-				opacity: eventItemInProgress ? 1 : 0.75
+				color: eventItemInProgress ? inProgressColor : (eventItemInPast ? PlasmaCore.ColorScope.disabledTextColor : PlasmaCore.ColorScope.textColor)
+				opacity: eventItemInProgress ? 1 : (eventItemInPast ? 0.25 : 0.75)
 				font.pointSize: -1
 				font.pixelSize: appletConfig.agendaFontSize
 				font.weight: eventItemInProgress ? inProgressFontWeight : Font.Normal
@@ -165,7 +175,9 @@ LinkRect {
 				readonly property bool showProperty: plasmoid.configuration.agendaShowEventDescription && text
 				visible: showProperty && !editEventForm.visible
 				text: Shared.renderText(model.description)
-				color: PlasmaCore.ColorScope.textColor
+				
+				color: eventItemInPast ? PlasmaCore.ColorScope.disabledTextColor : (eventItemInProgress ? inProgressColor : PlasmaCore.ColorScope.textColor)
+				
 				opacity: 0.75
 				font.pointSize: -1
 				font.pixelSize: appletConfig.agendaFontSize
@@ -221,8 +233,14 @@ LinkRect {
 							return i18n("Hangout")
 						}
 					}
+					contentItem: Text {
+						text: eventHangoutLink.text
+						color: eventItemInPast ? PlasmaCore.ColorScope.disabledTextColor : (eventItemInProgress ? inProgressColor : PlasmaCore.ColorScope.textColor)
+					}
 					icon.source: plasmoid.file("", "icons/hangouts.svg")
 					onClicked: Qt.openUrlExternally(externalLink)
+					flat: eventItemInPast
+
 				}
 			}
 

--- a/package/contents/ui/DayDelegate.qml
+++ b/package/contents/ui/DayDelegate.qml
@@ -223,7 +223,11 @@ MouseArea {
 			for (var i = 0; i < model.events.count; i++) {
 				var eventItem = model.events.get(i)
 				var line = ''
-				line += '<font color="' + eventItem.backgroundColor + '">■</font> '
+				var eventBullet = '■'
+				if(new Date(eventItem.end.dateTime) < new Date()) {
+					eventBullet = '✓'
+				}
+				line += '<font color="' + eventItem.backgroundColor + '">' + eventBullet + '</font> '
 				line += '<b>' + eventItem.summary + ':</b> '
 				line += LocaleFuncs.formatEventDuration(eventItem, {
 					relativeDate: thisDate,


### PR DESCRIPTION
With multiple calendars and dozens of meetings/events per calendar, it is hard to distinguish past events from current day/future events. Alongside the *inProgress state, an isPast property is added for events that is used to place a tickmark ✓ for past events and a square ■ for current/future events in the calendar view tooltip.

The theme for the event list items with an end date in the past is set to disabled, with the same tickmark prepended to the summary so they can be ignored faster.

The event button, if any, is flattened for the same reason.